### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/git-girl/git-check ${ZSH_CUSTOM:-~/.oh-my-zsh/custo
     ```
     plugins=( 
         # other plugins...
-        pseudo-projectile
+        git-check
     )
     ```
 3. Start a new terminal session.


### PR DESCRIPTION
Instructions referenced `pseudo-projectile` instead of `git-check`, update.